### PR TITLE
Fixed makefile parameter.  build output directly into target folder i…

### DIFF
--- a/src/main/java/com/simpligility/maven/plugins/androidndk/phase00clean/NdkCleanMojo.java
+++ b/src/main/java/com/simpligility/maven/plugins/androidndk/phase00clean/NdkCleanMojo.java
@@ -3,10 +3,8 @@ package com.simpligility.maven.plugins.androidndk.phase00clean;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.codehaus.plexus.util.FileUtils;
 
 import java.io.File;
-import java.io.IOException;
 
 /**
  * @author Johan Lindquist <johanlindquist@gmail.com>
@@ -53,39 +51,6 @@ public class NdkCleanMojo extends AbstractMojo
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException
     {
-        if ( ndkBuildLibsOutputDirectory.exists() )
-        {
-            if ( ! skipBuildLibsOutputDirectory )
-            {
-                getLog().debug( "Cleaning out native library code directory : " + ndkBuildLibsOutputDirectory
-                        .getAbsolutePath() );
-                try
-                {
-                    FileUtils.deleteDirectory( ndkBuildLibsOutputDirectory );
-                }
-                catch ( IOException e )
-                {
-                    getLog().error( "Error deleting directory: " + e.getMessage(), e );
-                }
-            }
-        }
-
-        if ( ndkBuildObjOutputDirectory.exists() )
-        {
-            if ( ! skipBuildObjsOutputDirectory )
-            {
-                getLog().debug(
-                        "Cleaning out native object code directory: " + ndkBuildObjOutputDirectory.getAbsolutePath() );
-                try
-                {
-                    FileUtils.deleteDirectory( ndkBuildObjOutputDirectory );
-                }
-                catch ( IOException e )
-                {
-                    getLog().error( "Error deleting directory: " + e.getMessage(), e );
-                }
-            }
-        }
 
     }
 

--- a/src/test/projects/native/native-code-nonstandard-structure/.gitignore
+++ b/src/test/projects/native/native-code-nonstandard-structure/.gitignore
@@ -1,0 +1,2 @@
+libs
+obj

--- a/src/test/projects/native/native-code-nonstandard-structure/AndroidManifest.xml
+++ b/src/test/projects/native/native-code-nonstandard-structure/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.acme.hellojni"
+          android:versionCode="1"
+          android:versionName="1.0">
+    <uses-sdk android:minSdkVersion="3" />
+</manifest>

--- a/src/test/projects/native/native-code-nonstandard-structure/pom.xml
+++ b/src/test/projects/native/native-code-nonstandard-structure/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (C) 2015 CNH Industrial NV. All rights reserved.
+  ~
+  ~ This software contains proprietary information of CNH Industrial NV. Neither
+  ~ receipt nor possession thereof confers any right to reproduce, use, or
+  ~ disclose in whole or in part any such information without written
+  ~ authorization from CNH Industrial NV.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                              http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+   <parent>
+      <groupId>com.simpligility.maven.plugins.samples</groupId>
+      <artifactId>native-parent</artifactId>
+      <version>1.0.0-SNAPSHOT</version>
+   </parent>
+
+  <artifactId>native-code-nonstandard-structure</artifactId>
+
+  <packaging>so</packaging>
+
+  <name>Android NDK - Native Sample Non-standard folder structure</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.simpligility.maven.plugins</groupId>
+        <artifactId>android-ndk-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <makefile>src/Android.mk</makefile>
+          <applicationMakefile>src/Application.mk</applicationMakefile>
+           <attachHeaderFiles>false</attachHeaderFiles>
+           <clearNativeArtifacts>false</clearNativeArtifacts>
+           <target>native-code-nonstandard-structure</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/test/projects/native/native-code-nonstandard-structure/src/Android.mk
+++ b/src/test/projects/native/native-code-nonstandard-structure/src/Android.mk
@@ -1,0 +1,22 @@
+# Copyright (C) 2009 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE    := native-code-nonstandard-structure
+LOCAL_SRC_FILES := hello-jni.c
+
+include $(BUILD_SHARED_LIBRARY)

--- a/src/test/projects/native/native-code-nonstandard-structure/src/Application.mk
+++ b/src/test/projects/native/native-code-nonstandard-structure/src/Application.mk
@@ -1,0 +1,1 @@
+APP_ABI := armeabi x86

--- a/src/test/projects/native/native-code-nonstandard-structure/src/hello-jni.c
+++ b/src/test/projects/native/native-code-nonstandard-structure/src/hello-jni.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2009 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include <string.h>
+#include <jni.h>
+
+/* This is a trivial JNI example where we use a native method
+ * to return a new VM String. See the corresponding Java source
+ * file located at:
+ *
+ *   apps/samples/hello-jni/project/src/com/example/HelloJni/HelloJni.java
+ */
+jstring
+Java_com_acme_hellojni_HelloJni_stringFromJNI( JNIEnv* env,
+                                                  jobject thiz )
+{
+    return (*env)->NewStringUTF(env, "Hello from Native JNI!");
+}

--- a/src/test/projects/native/pom.xml
+++ b/src/test/projects/native/pom.xml
@@ -12,7 +12,7 @@
   <name>Android NDK - Aggregator</name>
   <properties>
     <!-- at test time this will be overridden with snapshot version -->
-    <it-plugin.version>0.1.1-SNAPSHOT</it-plugin.version>
+    <it-plugin.version>1.0.1-SNAPSHOT</it-plugin.version>
   </properties>
 
   <modules>
@@ -25,7 +25,7 @@
     <module>java-with-native-dependency-x86-only</module>
     <module>mixed-java-native-code</module>
     <module>native-code-two-executions</module>
-
+    <module>native-code-nonstandard-structure</module>
     <!--
       <module>java-transient-dependency</module>
       <module>mixed-java-native-code</module>


### PR DESCRIPTION
- build output directly into target folder instead of moving files
  - use `NDK_OUT` and `NDK_LIBS_OUT` parameters
  - remove `clearNativeArtifacts` because no longer needed. as artifacts aren't placed under base directory.
- makefile parameter works now as correct `APP_BUILD_SCRIPT` parameter is passed to `ndk-build`
  - Added unit test to verify
  - old code used make style `-f makefile` which doesn't work for `ndk-build`
